### PR TITLE
Update nginx routing order

### DIFF
--- a/example-site-temp.conf
+++ b/example-site-temp.conf
@@ -28,7 +28,7 @@ server {
     
     # Handle routing for SPA
     location / {
-        try_files $uri $uri/ $uri.html /index.html;
+        try_files $uri.html $uri $uri/ /index.html;
     }
     
     # Static assets with cache headers

--- a/example-site.conf
+++ b/example-site.conf
@@ -54,7 +54,7 @@ server {
     
     # Handle routing for SPA
     location / {
-        try_files $uri $uri/ $uri.html /index.html;
+        try_files $uri.html $uri $uri/ /index.html;
     }
     
     # Static assets with cache headers


### PR DESCRIPTION
## Summary
- prevent 403 errors by checking `.html` files first in example nginx configs

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687d180e666483228fe1f2aa21bc200b