### PR TITLE
Add default root redirect to Chinese version

### DIFF
--- a/example-site-temp.conf
+++ b/example-site-temp.conf
@@ -27,6 +27,9 @@ server {
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
     
     # Handle routing for SPA
+    location = / {
+        return 302 /zh;
+    }
     location / {
         try_files $uri $uri/ $uri.html /index.html;
     }

--- a/example-site.conf
+++ b/example-site.conf
@@ -53,6 +53,9 @@ server {
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
     
     # Handle routing for SPA
+    location = / {
+        return 302 /zh;
+    }
     location / {
         try_files $uri $uri/ $uri.html /index.html;
     }


### PR DESCRIPTION
## Summary
- update nginx config for the example site
- make `/` redirect to `/zh` before other routes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d180e4dc083228fe48a15ccd4cc90